### PR TITLE
Fix typos & Replace absorbant macros

### DIFF
--- a/progproving.sty
+++ b/progproving.sty
@@ -31,9 +31,9 @@
 %--------------------------------------------------------------------%
 
 % ProgProving State
-% Usage : \state{<constraints>}
+% Usage: \state{<constraints>}
 % Requires Math mode
-\newcommand{\state}[1] {
+\newcommand*{\state}[1] {
     \left\{
         \begin{aligned}
             #1
@@ -42,56 +42,56 @@
 }
 
 % ProgProving Sequence of Instructions
-% Usage : \seq{<instructions>}
+% Usage: \seq{<instructions>}
 % Requires Math mode
-\newcommand{\seq}[1] {
+\newcommand*{\seq}[1] {
     \begin{aligned}
         #1
     \end{aligned}
 }
 
 % ProgProving sp
-% Usage : \ppsp{<instruction>}{<state>}
+% Usage: \ppsp{<instruction>}{<state>}
 % Requires Math mode
-\newcommand{\ppsp}[2] {sp\left(#1,#2\right)}
+\newcommand*{\ppsp}[2] {sp\left(#1,#2\right)}
 
 % ProgProving wp
-% Usage : \ppwp{<instruction>}{<state>}
+% Usage: \ppwp{<instruction>}{<state>}
 % Requires Math mode
-\newcommand{\ppwp}[2] {wp\left(#1,#2\right)}
+\newcommand*{\ppwp}[2] {wp\left(#1,#2\right)}
 
 % ProgProving Precondition
-% Usage : \pre
+% Usage: \pre
 \newcommand{\pre} {P}
 
 % ProgProving Postcondition
-% Usage : \post
+% Usage: \post
 \newcommand{\post} {Q}
 
 % ProgProving Invariant
-% Usage : \inv
+% Usage: \inv
 \newcommand{\inv} {I}
 
 % ProgProving Loop Condition
-% Usage : \cond
+% Usage: \cond
 \newcommand{\cond} {B}
 
 % ProgProving Loop Precondition
-% Usage : \lpre
+% Usage: \lpre
 \newcommand{\lpre} {R}
 
 % ProgProving Loop Postcondition
-% Usage : \lpost
+% Usage: \lpost
 \newcommand{\lpost} {T}
 
 % ProgProving Loop Initialisation
-% Usage : \init
+% Usage: \init
 \newcommand{\init} {INIT}
 
 % ProgProving Loop Iteration
-% Usage : \iter
+% Usage: \iter
 \newcommand{\iter} {ITER}
 
 % ProgProving Loop Termination
-% Usage : \term
+% Usage: \term
 \newcommand{\term} {TERM}


### PR DESCRIPTION
I replaced absorbant macros with non-absorbant ones (`\par` tokens rejected to ensure the function doesn't take more than one paragraph).
I also fixed some typos.